### PR TITLE
Added health checks

### DIFF
--- a/gateway-global-integration-api/appsettings.Development.json
+++ b/gateway-global-integration-api/appsettings.Development.json
@@ -36,7 +36,8 @@
     "Port": 5672,
     "RetryCount": 5,
     "GlobalIntegrationRoutingKey": "#.IntegrationEvent",
-    "GlobalIntegrationQueueName": "gateway_global_integration_evts"
+    "GlobalIntegrationQueueName": "gateway_global_integration_evts",
+    "HealthCheckTopicName": "newrsimessagesubmitted.integrationevent"
   },
   "AllowedHosts": "*"
 }

--- a/gateway-global-integration-api/appsettings.json
+++ b/gateway-global-integration-api/appsettings.json
@@ -18,7 +18,8 @@
     "Port": 5672,
     "RetryCount": 5,
     "GlobalIntegrationRoutingKey": "#.IntegrationEvent",
-    "GlobalIntegrationQueueName": "gateway_global_integration_evts"
+    "GlobalIntegrationQueueName": "gateway_global_integration_evts",
+    "HealthCheckTopicName": "newrsimessagesubmitted.integrationevent"
   },
   "ClientUrls": {
     "GlobalIntegrationUI": "http://localhost:59281"

--- a/gateway-global-integration-api/gateway-global-integration-api.csproj
+++ b/gateway-global-integration-api/gateway-global-integration-api.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="8.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.1" />


### PR DESCRIPTION
Fixes [AB#361](https://dev.azure.com/BritishLibrary-AppDev/f1fcc77c-6d52-4a59-849c-0a2a32895139/_workitems/edit/361)

Added health checks for the Global Integration API service, database, Azure Service Bus or RabbitMQ

Added app setting to specify what topic to use when performing the Service Bus health check. I don't think we need to check every single topic from every application as that might be too many requests, but can change if it we think its necessary